### PR TITLE
feat(ci): add release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,3 +20,39 @@ jobs:
           version: 18.09.3
       # specify any bash command here prefixed with `run: `
       - run: make all-ci
+  release:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.13.0
+    environment:
+      GOPROXY: direct
+    working_directory: /go/src/github.com/docker/cnab-to-oci
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.09.3
+      - run: >
+          go get -u github.com/tcnksm/ghr
+          last_tag=$(git describe --tags ${CIRCLE_TAG}^ --abbrev=0 --always)
+          ghr \
+            -u cnabio \
+            -r cnab-to-oci \
+            -n "cnab-to-oci ${CIRCLE_TAG}" \
+            -b "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^${last_tag})" \
+            ${CIRCLE_TAG}
+
+workflows:
+  version: 2
+  untagged-build:
+    jobs:
+      - build
+  tagged-build:
+    jobs:
+      - release:
+          requires:
+            - build
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,3 +44,15 @@ jobs:
             -n "cnab-to-oci ${CIRCLE_TAG}" \
             -b "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^${last_tag})" \
             ${CIRCLE_TAG}
+
+# workflows are required when using the CircleCI GitHub App
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build
+  release:
+    jobs:
+      - build
+      - release
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
       branches:
         ignore: /.*/
     docker:
-      - image: circleci/golang:1.13.0
+      - image: circleci/golang:1.13.7
     environment:
       GOPROXY: direct
     working_directory: /go/src/github.com/cnabio/cnab-to-oci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,15 +22,12 @@ jobs:
       - run: make all-ci
   release:
     docker:
-      # specify the version
       - image: circleci/golang:1.13.0
     environment:
       GOPROXY: direct
     working_directory: /go/src/github.com/docker/cnab-to-oci
     steps:
       - checkout
-      - setup_remote_docker:
-          version: 18.09.3
       - run: >
           go get -u github.com/tcnksm/ghr
           last_tag=$(git describe --tags ${CIRCLE_TAG}^ --abbrev=0 --always)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,24 +1,15 @@
-# Golang CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-go/ for more details
 version: 2
 jobs:
   build:
     docker:
-      # specify the version
       - image: circleci/golang:1.13.7
     environment:
       GOPROXY: direct
-    #### TEMPLATE_NOTE: go expects specific checkout path representing url
-    #### expecting it in the form of
-    ####   /go/src/github.com/circleci/go-tool
-    ####   /go/src/bitbucket.org/circleci/go-tool
     working_directory: /go/src/github.com/cnabio/cnab-to-oci
     steps:
       - checkout
       - setup_remote_docker:
           version: 18.09.3
-      # specify any bash command here prefixed with `run: `
       - run: make all-ci
   release:
     docker:
@@ -40,7 +31,7 @@ jobs:
               -b "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^${last_tag})" \
               ${CIRCLE_TAG}
 
-# workflows are required when using the CircleCI GitHub App
+# Workflows are required when using the CircleCI Checks App
 workflows:
   version: 2
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,13 @@ jobs:
       # specify any bash command here prefixed with `run: `
       - run: make all-ci
   release:
+    requires:
+      - build
+    filters:
+      tags:
+        only: /^v.*/
+      branches:
+        ignore: /.*/
     docker:
       - image: circleci/golang:1.13.0
     environment:
@@ -37,19 +44,3 @@ jobs:
             -n "cnab-to-oci ${CIRCLE_TAG}" \
             -b "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^${last_tag})" \
             ${CIRCLE_TAG}
-
-workflows:
-  version: 2
-  untagged-build:
-    jobs:
-      - build
-  tagged-build:
-    jobs:
-      - release:
-          requires:
-            - build
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   build:
     docker:
       # specify the version
-      - image: circleci/golang:1.13.0
+      - image: circleci/golang:1.13.7
     environment:
       GOPROXY: direct
     #### TEMPLATE_NOTE: go expects specific checkout path representing url
@@ -32,7 +32,7 @@ jobs:
       - image: circleci/golang:1.13.0
     environment:
       GOPROXY: direct
-    working_directory: /go/src/github.com/docker/cnab-to-oci
+    working_directory: /go/src/github.com/cnabio/cnab-to-oci
     steps:
       - checkout
       - run: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,13 +21,6 @@ jobs:
       # specify any bash command here prefixed with `run: `
       - run: make all-ci
   release:
-    requires:
-      - build
-    filters:
-      tags:
-        only: /^v.*/
-      branches:
-        ignore: /.*/
     docker:
       - image: circleci/golang:1.13.7
     environment:
@@ -35,24 +28,30 @@ jobs:
     working_directory: /go/src/github.com/cnabio/cnab-to-oci
     steps:
       - checkout
-      - run: >
-          go get -u github.com/tcnksm/ghr
-          last_tag=$(git describe --tags ${CIRCLE_TAG}^ --abbrev=0 --always)
-          ghr \
-            -u cnabio \
-            -r cnab-to-oci \
-            -n "cnab-to-oci ${CIRCLE_TAG}" \
-            -b "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^${last_tag})" \
-            ${CIRCLE_TAG}
+      - run:
+          name: "Publish release on GitHub"
+          command: |
+            go get -u github.com/tcnksm/ghr
+            last_tag=$(git describe --tags ${CIRCLE_TAG}^ --abbrev=0 --always)
+            ghr \
+              -u cnabio \
+              -r cnab-to-oci \
+              -n "cnab-to-oci ${CIRCLE_TAG}" \
+              -b "$(git log --no-merges --pretty=format:'- %s %H (%aN)' HEAD ^${last_tag})" \
+              ${CIRCLE_TAG}
 
 # workflows are required when using the CircleCI GitHub App
 workflows:
   version: 2
-  build:
+  main:
     jobs:
       - build
-  release:
-    jobs:
-      - build
-      - release
+      - release:
+          requires:
+            - build
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
 


### PR DESCRIPTION
* adds a release job to the current circleci config

Adding in Draft as I'm a circleci newbie!  Cobbled together after quick looks at docs/examples... Perhaps @silvin-lubecki can lend a hand in review/testing/etc. ?

TODO: 
  - [x] add an `GITHUB_TOKEN` env var to the circleci project config that the `release` job can use, with the value of a valid github token for creating releases on this repo.

Contributes towards https://github.com/cnabio/cnab-to-oci/issues/90