### PR TITLE
Include digest when pulling a bundle

### DIFF
--- a/cmd/cnab-to-oci/pull.go
+++ b/cmd/cnab-to-oci/pull.go
@@ -43,7 +43,7 @@ func runPull(opts pullOptions) error {
 		return err
 	}
 
-	b, relocationMap, err := remotes.Pull(context.Background(), ref, createResolver(opts.insecureRegistries))
+	b, relocationMap, _, err := remotes.Pull(context.Background(), ref, createResolver(opts.insecureRegistries))
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,6 @@ require (
 	google.golang.org/grpc v1.29.1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
-	gotest.tools v2.2.0+incompatible
 	gotest.tools/v3 v3.0.3
 )
 

--- a/remotes/pull_test.go
+++ b/remotes/pull_test.go
@@ -46,7 +46,10 @@ func TestPull(t *testing.T) {
 		fetcher: fetcher,
 		resolvedDescriptors: []ocischemav1.Descriptor{
 			// Bundle index descriptor
-			{MediaType: ocischemav1.MediaTypeImageIndex},
+			{
+				MediaType: ocischemav1.MediaTypeImageIndex,
+				Digest:    tests.BundleDigest,
+			},
 			// Bundle config manifest descriptor
 			{
 				MediaType: ocischemav1.MediaTypeDescriptor,
@@ -60,10 +63,15 @@ func TestPull(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Pull the CNAB and get the bundle
-	b, _, err = Pull(context.Background(), ref, resolver)
+	b, rm, digest, err := Pull(context.Background(), ref, resolver)
 	assert.NilError(t, err)
 	expectedBundle := tests.MakeTestBundle()
 	assert.DeepEqual(t, expectedBundle, b)
+
+	expectedRelocationMap := tests.MakeRelocationMap()
+	assert.DeepEqual(t, expectedRelocationMap, rm)
+
+	assert.Equal(t, tests.BundleDigest, digest, "incorrect digest pulled")
 }
 
 // nolint: lll
@@ -76,7 +84,7 @@ func ExamplePull() {
 	}
 
 	// Pull the CNAB, get the bundle and the associated relocation map
-	resultBundle, relocationMap, err := Pull(context.Background(), ref, resolver)
+	resultBundle, relocationMap, _, err := Pull(context.Background(), ref, resolver)
 	if err != nil {
 		panic(err)
 	}

--- a/remotes/push_test.go
+++ b/remotes/push_test.go
@@ -93,8 +93,9 @@ func TestPush(t *testing.T) {
 	assert.NilError(t, err)
 
 	// push the bundle
-	_, err = Push(context.Background(), b, tests.MakeRelocationMap(), ref, resolver, true)
+	descriptor, err := Push(context.Background(), b, tests.MakeRelocationMap(), ref, resolver, true)
 	assert.NilError(t, err)
+	assert.Equal(t, tests.BundleDigest, descriptor.Digest)
 	assert.Equal(t, len(resolver.pushedReferences), 3)
 	assert.Equal(t, len(pusher.pushedDescriptors), 3)
 	assert.Equal(t, len(pusher.buffers), 3)

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -5,9 +5,12 @@ import (
 	"github.com/cnabio/cnab-go/bundle/definition"
 	"github.com/cnabio/cnab-to-oci/relocation"
 	"github.com/docker/distribution/manifest/schema2"
+	"github.com/opencontainers/go-digest"
 	ocischema "github.com/opencontainers/image-spec/specs-go"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+const BundleDigest digest.Digest = "sha256:4cfae04045c6f0fd14330ab86dea9694fb19ce9602ba2da0af8c826fc0053631"
 
 // MakeTestBundle creates a simple bundle for tests
 func MakeTestBundle() *bundle.Bundle {


### PR DESCRIPTION
When pulling a bundle, return the digest of the bundle as well. This allows clients to record the digest of a bundle that was pulled by a tag, and use it for comparison later or allowing pulling from tag the first time and then always pulling from the known digest on subsequent bundle executions.