### PR TITLE
chore: add Carolyn Van Slyck as a codeowner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,7 @@
 # This file is described here:  https://help.github.com/en/articles/about-code-owners
 
 # Global Owners: These members are Core Maintainers of cnab-to-oci
-CODEOWNERS      @silvin-lubecki @radu-matei
-LICENSE         @silvin-lubecki @radu-matei
-CONTRIBUTING.md @silvin-lubecki @radu-matei
-GOVERNANCE.md   @silvin-lubecki @radu-matei
+CODEOWNERS      @silvin-lubecki @radu-matei @carolynvs
+LICENSE         @silvin-lubecki @radu-matei @carolynvs
+CONTRIBUTING.md @silvin-lubecki @radu-matei @carolynvs
+GOVERNANCE.md   @silvin-lubecki @radu-matei @carolynvs


### PR DESCRIPTION
Carolyn has been a CNAB maintainer for the longest time, and she has
been making amazing contributions to the project.
This commit updates the CODEOWNERS file to reflect that.

Signed-off-by: Radu Matei <radu.matei@fermyon.com>