### PR TITLE
remotes: remove reference to pkg/errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,6 @@ require (
 	github.com/docker/go v1.5.1-1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.2.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -41,6 +40,7 @@ require (
 	github.com/moby/locker v1.0.1 // indirect
 	github.com/moby/term v0.0.0-20210610120745-9d4ed1856297 // indirect
 	github.com/morikuni/aec v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.11.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.30.0 // indirect

--- a/remotes/pull.go
+++ b/remotes/pull.go
@@ -3,6 +3,7 @@ package remotes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/docker/distribution/registry/client/auth"
 	"github.com/opencontainers/go-digest"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // Pull pulls a bundle from an OCI Image Index manifest
@@ -47,7 +47,7 @@ func getIndex(ctx context.Context, ref auth.Scope, resolver remotes.Resolver) (o
 	logger.Debug("Getting OCI Index Descriptor")
 	resolvedRef, indexDescriptor, err := resolver.Resolve(withMutedContext(ctx), ref.String())
 	if err != nil {
-		if errors.Cause(err) == errdefs.ErrNotFound {
+		if errors.Is(err, errdefs.ErrNotFound) {
 			return ocischemav1.Index{}, ocischemav1.Descriptor{}, err
 		}
 		return ocischemav1.Index{}, ocischemav1.Descriptor{}, fmt.Errorf("failed to resolve bundle manifest %q: %s", ref, err)

--- a/remotes/push.go
+++ b/remotes/push.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,7 +27,6 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/opencontainers/go-digest"
 	ocischemav1 "github.com/opencontainers/image-spec/specs-go/v1"
-	"github.com/pkg/errors"
 )
 
 // ManifestOption is a callback used to customize a manifest before pushing it
@@ -202,20 +202,20 @@ func pushPayload(ctx context.Context, resolver remotes.Resolver, reference strin
 	}
 	writer, err := pusher.Push(ctx, descriptor)
 	if err != nil {
-		if errors.Cause(err) == errdefs.ErrAlreadyExists {
+		if errors.Is(err, errdefs.ErrAlreadyExists) {
 			return nil
 		}
 		return err
 	}
 	defer writer.Close()
 	if _, err := writer.Write(payload); err != nil {
-		if errors.Cause(err) == errdefs.ErrAlreadyExists {
+		if errors.Is(err, errdefs.ErrAlreadyExists) {
 			return nil
 		}
 		return err
 	}
 	err = writer.Commit(ctx, descriptor.Size, descriptor.Digest)
-	if errors.Cause(err) == errdefs.ErrAlreadyExists {
+	if errors.Is(err, errdefs.ErrAlreadyExists) {
 		return nil
 	}
 	return err


### PR DESCRIPTION
when containderd is upgraded, tests started to break due to the changes in containerd's error handling. 
This PR switches error handling from "github.com/pkg/errors" to go native "errors" package

